### PR TITLE
Fix windows compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ secp256k1 = {version = "^0.21", features = ["rand", "rand-std", "serde", "bitcoi
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = {version = "^1.0", features = ["preserve_order"]}
 hex = "^0.4"
-rusqlite = { version = "^0.26", features = ["limits"]}
+rusqlite = { version = "^0.26", features = ["limits","bundled"]}
 r2d2 = "^0.8"
 r2d2_sqlite = "^0.19"
 lazy_static = "^1.4"


### PR DESCRIPTION
Using 'bundled' is recommended by https://github.com/rusqlite/rusqlite#usage to avoid common build issues