### PR TITLE
docker: macos arm64 config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 nostr.db
+nostr.db-shm
+nostr.db-wal

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/rust:1.62.0@sha256:8220e4fbb22a07b78e6472cdf8f5fb8913a04974c26b130177b73a8a64334541 as builder
+FROM docker.io/rust:latest as builder
 
 RUN USER=root cargo new --bin nostr-rs-relay
 WORKDIR ./nostr-rs-relay
@@ -12,9 +12,10 @@ COPY ./src ./src
 RUN rm ./target/release/deps/nostr*relay*
 RUN cargo build --release
 
-FROM docker.io/library/debian:bullseye-20220622-slim@sha256:89e9d812b34f393bddc3ff289f0036a3d9efc7e2f7289ec902c6427b69f39649
+FROM docker.io/debian:latest
 ARG APP=/usr/src/app
 ARG APP_DATA=/usr/src/app/db
+RUN apt update && apt -y install openssl
 RUN apt-get update \
     && apt-get install -y ca-certificates tzdata sqlite3 libc6 \
     && rm -rf /var/lib/apt/lists/*

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,0 +1,14 @@
+-: build
+	mkdir -p data
+build:
+	docker build -t nostr-rs-relay .
+run:
+	docker run -it -p 7000:8080 \
+		--mount src=$(PWD)/config.toml,target=/usr/src/app/config.toml,type=bind \
+		--mount src=$(PWD)/data,target=/usr/src/app/db,type=bind \
+		nostr-rs-relay
+noscl:
+	go install github.com/fiatjaf/noscl@latest
+all: - init build run noscl
+init:
+	test go && brew install golang || apt install golang-go || true

--- a/config.toml
+++ b/config.toml
@@ -20,7 +20,7 @@ description = "A newly created nostr-rs-relay.\n\nCustomize this with your own i
 # Directory for SQLite files.  Defaults to the current directory.  Can
 # also be specified (and overriden) with the "--db dirname" command
 # line option.
-data_directory = "."
+data_directory = "data"
 
 # Database connection pool settings for subscribers:
 

--- a/macos_toggle_airplay.sh
+++ b/macos_toggle_airplay.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+osascript <<EOS
+
+on toggle()
+	tell application "System Preferences" to reveal pane id "com.apple.preferences.sharing"
+
+	tell application "System Events" to tell window 1 of application process "System Preferences"
+
+		repeat until exists checkbox 1 of (first row of table 1 of scroll area 1 of group 1 whose value of static text 1 is "AirPlay Receiver")
+			delay 0.1
+		end repeat
+		if value of checkbox 1 of (first row of table 1 of scroll area 1 of group 1 whose value of static text 1 is "AirPlay Receiver") as boolean then
+			click checkbox 1 of (first row of table 1 of scroll area 1 of group 1 whose value of static text 1 is "AirPlay Receiver")
+		else
+			click checkbox 1 of (first row of table 1 of scroll area 1 of group 1 whose value of static text 1 is "AirPlay Receiver")
+		end if
+	end tell
+end toggle
+
+if application "System Preferences" is not running then
+	tell application "System Preferences" to activate
+	toggle()
+	tell application "System Preferences" to quit
+else
+	toggle()
+	tell application "System Preferences" to quit
+end if
+
+EOS


### PR DESCRIPTION
Pinning the builder image to a specific @sha256:hash blocks using the docker container on MacOS Arm64 - by using rust:latest & debian:latest the container is able to be used on MacOS Arm64 - Docker selects the appropriate architecture.