### PR TITLE
Add event kind blacklist

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -99,6 +99,11 @@ reject_future_seconds = 1800
 # backpressure to senders if writes are slow.
 #event_persist_buffer = 4096
 
+# Event kind blacklist. Events with these kinds will be discarded.
+#event_kind_blacklist = [
+#    70202,
+#]
+
 [authorization]
 # Pubkey addresses in this array are whitelisted for event publishing.
 # Only valid events by these authors will be accepted, if the variable

--- a/src/config.rs
+++ b/src/config.rs
@@ -60,6 +60,7 @@ pub struct Limits {
     pub max_ws_frame_bytes: Option<usize>,
     pub broadcast_buffer: usize, // events to buffer for subscribers (prevents slow readers from consuming memory)
     pub event_persist_buffer: usize, // events to buffer for database commits (block senders if database writes are too slow)
+    pub event_kind_blacklist: Option<Vec<u64>>
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -225,6 +226,7 @@ impl Default for Settings {
                 max_ws_frame_bytes: Some(2 << 17),   // 128K
                 broadcast_buffer: 16384,
                 event_persist_buffer: 4096,
+                event_kind_blacklist: None,
             },
             authorization: Authorization {
                 pubkey_whitelist: None, // Allow any address to publish


### PR DESCRIPTION
Adds a list to the config where you can specify which event kinds to blacklist. The blacklist check will run right after verifying that the pubkey is allowed to post events to the relay.

Fixes #34 