### PR TITLE
Opentimestamps field impl

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ mirrored on [GitHub](https://github.com/scsibug/nostr-rs-relay).
   * Hide old metadata events
   * Id/Author prefix search
 - [x] NIP-02: [Contact List and Petnames](https://github.com/nostr-protocol/nips/blob/master/02.md)
-- [ ] NIP-03: [OpenTimestamps Attestations for Events](https://github.com/nostr-protocol/nips/blob/master/03.md)
+- [x] NIP-03: [OpenTimestamps Attestations for Events](https://github.com/nostr-protocol/nips/blob/master/03.md)
 - [x] NIP-05: [Mapping Nostr keys to DNS-based internet identifiers](https://github.com/nostr-protocol/nips/blob/master/05.md)
 - [x] NIP-09: [Event Deletion](https://github.com/nostr-protocol/nips/blob/master/09.md)
 - [x] NIP-11: [Relay Information Document](https://github.com/nostr-protocol/nips/blob/master/11.md)

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -371,6 +371,7 @@ mod tests {
             content: "".to_owned(),
             sig: "".to_owned(),
             tagidx: None,
+            ots: None,
         };
         assert!(s.interested_in_event(&e));
         Ok(())
@@ -390,6 +391,7 @@ mod tests {
             content: "".to_owned(),
             sig: "".to_owned(),
             tagidx: None,
+            ots: None,
         };
         assert!(s.interested_in_event(&e));
         Ok(())
@@ -409,6 +411,7 @@ mod tests {
             content: "".to_owned(),
             sig: "".to_owned(),
             tagidx: None,
+            ots: None,
         };
         assert!(!s.interested_in_event(&e));
         Ok(())
@@ -429,6 +432,7 @@ mod tests {
             content: "".to_owned(),
             sig: "".to_owned(),
             tagidx: None,
+            ots: None,
         };
         assert!(s.interested_in_event(&e));
         Ok(())
@@ -453,6 +457,7 @@ mod tests {
             content: "".to_owned(),
             sig: "".to_owned(),
             tagidx: None,
+            ots: None,
         };
         assert!(s_in.interested_in_event(&e));
         assert!(!s_before.interested_in_event(&e));
@@ -475,6 +480,7 @@ mod tests {
             content: "".to_owned(),
             sig: "".to_owned(),
             tagidx: None,
+            ots: None,
         };
         assert!(!s.interested_in_event(&e));
         Ok(())
@@ -494,6 +500,7 @@ mod tests {
             content: "".to_owned(),
             sig: "".to_owned(),
             tagidx: None,
+            ots: None,
         };
         assert!(s.interested_in_event(&e));
         Ok(())
@@ -513,6 +520,7 @@ mod tests {
             content: "".to_owned(),
             sig: "".to_owned(),
             tagidx: None,
+            ots: None,
         };
         assert!(s.interested_in_event(&e));
         Ok(())
@@ -532,6 +540,7 @@ mod tests {
             content: "".to_owned(),
             sig: "".to_owned(),
             tagidx: None,
+            ots: None,
         };
         assert!(s.interested_in_event(&e));
         Ok(())
@@ -551,6 +560,7 @@ mod tests {
             content: "".to_owned(),
             sig: "".to_owned(),
             tagidx: None,
+            ots: None,
         };
         assert!(s.interested_in_event(&e));
         Ok(())
@@ -570,6 +580,7 @@ mod tests {
             content: "".to_owned(),
             sig: "".to_owned(),
             tagidx: None,
+            ots: None,
         };
         assert!(!s.interested_in_event(&e));
         Ok(())


### PR DESCRIPTION
I'm playing around with opentimestamps locally and decided to use this relay for testing. I'm not sure if you guys want this change, but I'll open it anyway. In case you do, please double check the changes as I'm not completely familiar with the system. I'm not sure what type ots column should be in database or its size. The current VARCHAR(5000) was picked a bit randomly and I didn't test for edge cases of what happens if we go over. I also didn't know if it should be nullable or set to `""` which is the first comment in the schema migration function. Feel free to change whatever you like or close this PR and push some changes directly.

NOTE: One of the tests expects `data == ser(deser(data))` to hold. I had to set `"tags"=[]` there because `"tags":null` turned into `"tags":[]` with this.