### PR TITLE
refactor: Fix clippy warnings

### DIFF
--- a/src/bin/bulkloader.rs
+++ b/src/bin/bulkloader.rs
@@ -35,7 +35,7 @@ pub fn main() -> Result<()> {
 	// ensure the schema version is current.
 	if version != DB_VERSION {
 	    info!("version is not current, exiting");
-	    panic!("cannot write to schema other than v{}", DB_VERSION);
+	    panic!("cannot write to schema other than v{DB_VERSION}");
 	}
     }
     // this channel will contain parsed events ready to be inserted

--- a/src/delegation.rs
+++ b/src/delegation.rs
@@ -108,7 +108,7 @@ impl ConditionQuery {
     sigstr: &str,
 ) -> Option<ConditionQuery> {
     // form the token
-    let tok = format!("nostr:delegation:{}:{}", delegatee, cond_query);
+    let tok = format!("nostr:delegation:{delegatee}:{cond_query}");
     // form SHA256 hash
     let digest: sha256::Hash = sha256::Hash::hash(tok.as_bytes());
     let sig = schnorr::Signature::from_str(sigstr).unwrap();

--- a/src/event.rs
+++ b/src/event.rs
@@ -143,9 +143,9 @@ impl Event {
             let default = "".to_string();
             let dvals:Vec<&String> = self.tags
                 .iter()
-                .filter(|x| x.len() >= 1)
+                .filter(|x| !x.is_empty())
                 .filter(|x| x.get(0).unwrap() == "d")
-                .map(|x| x.get(1).unwrap_or_else(|| &default)).take(1)
+                .map(|x| x.get(1).unwrap_or(&default)).take(1)
                 .collect();
             let dval_first = dvals.get(0);
             match dval_first {
@@ -292,7 +292,7 @@ impl Event {
         let c = c_opt.unwrap();
         // * compute the sha256sum.
         let digest: sha256::Hash = sha256::Hash::hash(c.as_bytes());
-        let hex_digest = format!("{:x}", digest);
+        let hex_digest = format!("{digest:x}");
         // * ensure the id matches the computed sha256sum.
         if self.id != hex_digest {
             debug!("event id does not match digest");

--- a/src/nip05.rs
+++ b/src/nip05.rs
@@ -107,7 +107,7 @@ impl std::fmt::Display for Nip05Name {
 /// Check if the specified username and address are present and match in this response body
 fn body_contains_user(username: &str, address: &str, bytes: &hyper::body::Bytes) -> Result<bool> {
     // convert the body into json
-    let body: serde_json::Value = serde_json::from_slice(&bytes)?;
+    let body: serde_json::Value = serde_json::from_slice(bytes)?;
     // ensure we have a names object.
     let names_map = body
         .as_object()

--- a/src/repo/postgres_migration.rs
+++ b/src/repo/postgres_migration.rs
@@ -81,7 +81,7 @@ async fn run_migration(migration: impl Migration, db: &PostgresPool) -> Migratio
         .unwrap();
 
     transaction.commit().await.unwrap();
-    return MigrationResult::Upgraded;
+    MigrationResult::Upgraded
 }
 
 mod m001 {
@@ -216,7 +216,7 @@ CREATE INDEX tag_value_hex_idx ON tag USING btree (value_hex);
                         let q = "INSERT INTO tag (event_id, \"name\", value_hex) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING;";
                         sqlx::query(q)
                             .bind(&event_id)
-                            .bind(&tagname)
+                            .bind(tagname)
                             .bind(hex::decode(tagval).ok())
                             .execute(&mut update_tx)
                             .await?;
@@ -224,7 +224,7 @@ CREATE INDEX tag_value_hex_idx ON tag USING btree (value_hex);
                         let q = "INSERT INTO tag (event_id, \"name\", value) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING;";
                         sqlx::query(q)
                             .bind(&event_id)
-                            .bind(&tagname)
+                            .bind(tagname)
                             .bind(tagval.as_bytes())
                             .execute(&mut update_tx)
                             .await?;

--- a/src/repo/sqlite_migration.rs
+++ b/src/repo/sqlite_migration.rs
@@ -211,13 +211,12 @@ pub fn upgrade_db(conn: &mut PooledConnection) -> Result<usize> {
         }
         // Database is current, all is good
         Ordering::Equal => {
-            debug!("Database version was already current (v{})", DB_VERSION);
+            debug!("Database version was already current (v{DB_VERSION})");
         }
         // Database is newer than what this code understands, abort
         Ordering::Greater => {
             panic!(
-                "Database version is newer than supported by this executable (v{} > v{})",
-                curr_version, DB_VERSION
+                "Database version is newer than supported by this executable (v{curr_version} > v{DB_VERSION})",
             );
         }
     }

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -70,7 +70,7 @@ impl Serialize for ReqFilter {
         if let Some(tags) = &self.tags {
             for (k,v) in tags {
                 let vals:Vec<&String> = v.iter().collect();
-                map.serialize_entry(&format!("#{}",k), &vals)?;
+                map.serialize_entry(&format!("#{k}"), &vals)?;
             }
         }
         map.end()


### PR DESCRIPTION
Fixed all clippy warnings.

<details>
<pre>
warning: variables can be used directly in the `format!` string
   --> src/delegation.rs:111:15
    |
111 |     let tok = format!("nostr:delegation:{}:{}", delegatee, cond_query);
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
    = note: `#[warn(clippy::uninlined_format_args)]` on by default
help: change this to
    |
111 -     let tok = format!("nostr:delegation:{}:{}", delegatee, cond_query);
111 +     let tok = format!("nostr:delegation:{delegatee}:{cond_query}");
    |

warning: length comparison to one
   --> src/event.rs:146:29
    |
146 |                 .filter(|x| x.len() >= 1)
    |                             ^^^^^^^^^^^^ help: using `!is_empty` is clearer and more explicit: `!x.is_empty()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#len_zero
    = note: `#[warn(clippy::len_zero)]` on by default

warning: unnecessary closure used to substitute value for `Option::None`
   --> src/event.rs:148:26
    |
148 |                 .map(|x| x.get(1).unwrap_or_else(|| &default)).take(1)
    |                          ^^^^^^^^^---------------------------
    |                                   |
    |                                   help: use `unwrap_or(..)` instead: `unwrap_or(&default)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_lazy_evaluations
    = note: `#[warn(clippy::unnecessary_lazy_evaluations)]` on by default

warning: variables can be used directly in the `format!` string
   --> src/event.rs:295:26
    |
295 |         let hex_digest = format!("{:x}", digest);
    |                          ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
help: change this to
    |
295 -         let hex_digest = format!("{:x}", digest);
295 +         let hex_digest = format!("{digest:x}");
    |

warning: this expression creates a reference which is immediately dereferenced by the compiler
   --> src/nip05.rs:110:58
    |
110 |     let body: serde_json::Value = serde_json::from_slice(&bytes)?;
    |                                                          ^^^^^^ help: change this to: `bytes`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
    = note: `#[warn(clippy::needless_borrow)]` on by default

warning: unneeded late initialization
   --> src/repo/sqlite.rs:126:13
    |
126 |             let repl_count;
    |             ^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_late_init
    = note: `#[warn(clippy::needless_late_init)]` on by default
help: declare `repl_count` here
    |
127 |             let repl_count = if is_lower_hex(&d_tag) && (d_tag.len() % 2 == 0) {
    |             ++++++++++++++++
help: remove the assignments from the branches
    |
128 ~                 tx.query_row(
129 |                     "SELECT e.id FROM event e LEFT JOIN tag t ON e.id=t.event_id WHERE e.author=? AND e.kind=? AND t.name='d' AND t.value_hex=? AND e.created_at >= ? LIMIT 1;",
130 ~                     params![pubkey_blob, e.kind, hex::decode(d_tag).ok(), e.created_at],|row| row.get::<usize, usize>(0))
131 |             } else {
132 ~                 tx.query_row(
133 |                     "SELECT e.id FROM event e LEFT JOIN tag t ON e.id=t.event_id WHERE e.author=? AND e.kind=? AND t.name='d' AND t.value=? AND e.created_at >= ? LIMIT 1;",
134 ~                     params![pubkey_blob, e.kind, d_tag, e.created_at],|row| row.get::<usize, usize>(0))
    |
help: add a semicolon after the `if` expression
    |
135 |             };
    |              +

warning: unneeded late initialization
   --> src/repo/sqlite.rs:204:13
    |
204 |             let update_count;
    |             ^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_late_init
help: declare `update_count` here
    |
205 |             let update_count = if is_lower_hex(&d_tag) && (d_tag.len() % 2 == 0) {
    |             ++++++++++++++++++
help: remove the assignments from the branches
    |
206 ~                 tx.execute(
207 |                     "DELETE FROM event WHERE kind=? AND author=? AND id IN (SELECT e.id FROM event e LEFT JOIN tag t ON e.id=t.event_id WHERE e.kind=? AND e.author=? AND t.name='d' AND t.value_hex=? ORDER BY created_at DESC LIMIT -1 OFFSET 1);",
208 ~                     params![e.kind, pubkey_blob, e.kind, pubkey_blob, hex::decode(d_tag).ok()])?
209 |             } else {
210 ~                 tx.execute(
211 |                     "DELETE FROM event WHERE kind=? AND author=? AND id IN (SELECT e.id FROM event e LEFT JOIN tag t ON e.id=t.event_id WHERE e.kind=? AND e.author=? AND t.name='d' AND t.value=? ORDER BY created_at DESC LIMIT -1 OFFSET 1);",
212 ~                     params![e.kind, pubkey_blob, e.kind, pubkey_blob, d_tag])?
    |
help: add a semicolon after the `if` expression
    |
213 |             };
    |              +

warning: this expression creates a reference which is immediately dereferenced by the compiler
   --> src/repo/sqlite.rs:368:57
    |
368 |                     let (q, p, idx) = query_from_filter(&filter);
    |                                                         ^^^^^^^ help: change this to: `filter`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: variables can be used directly in the `format!` string
   --> src/repo/sqlite.rs:722:72
    |
722 |     let idx_stmt = idx_name.as_ref().map_or_else(|| "".to_owned(), |i| format!("INDEXED BY {}",i));
    |                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
help: change this to
    |
722 -     let idx_stmt = idx_name.as_ref().map_or_else(|| "".to_owned(), |i| format!("INDEXED BY {}",i));
722 +     let idx_stmt = idx_name.as_ref().map_or_else(|| "".to_owned(), |i| format!("INDEXED BY {i}"));
    |

warning: variables can be used directly in the `format!` string
   --> src/repo/sqlite.rs:723:21
    |
723 |     let mut query = format!("SELECT e.content FROM event e {}", idx_stmt);
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
help: change this to
    |
723 -     let mut query = format!("SELECT e.content FROM event e {}", idx_stmt);
723 +     let mut query = format!("SELECT e.content FROM event e {idx_stmt}");
    |

warning: length comparison to zero
   --> src/repo/sqlite.rs:817:16
    |
817 |             if str_vals.len() == 0 {
    |                ^^^^^^^^^^^^^^^^^^^ help: using `is_empty` is clearer and more explicit: `str_vals.is_empty()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#len_zero

warning: variables can be used directly in the `format!` string
   --> src/repo/sqlite.rs:821:34
    |
821 |                   let tag_clause = format!(
    |  __________________________________^
822 | |                     "e.id IN (SELECT t.event_id FROM tag t WHERE (name=? AND {}))",
823 | |                     blob_clause
824 | |                 );
    | |_________________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args

warning: length comparison to zero
   --> src/repo/sqlite.rs:830:23
    |
830 |             } else if blob_vals.len() == 0 {
    |                       ^^^^^^^^^^^^^^^^^^^^ help: using `is_empty` is clearer and more explicit: `blob_vals.is_empty()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#len_zero

warning: variables can be used directly in the `format!` string
   --> src/repo/sqlite.rs:834:34
    |
834 |                   let tag_clause = format!(
    |  __________________________________^
835 | |             "e.id IN (SELECT t.event_id FROM tag t WHERE (name=? AND {}))",
836 | |                     str_clause
837 | |                 );
    | |_________________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args

warning: variables can be used directly in the `format!` string
   --> src/repo/sqlite.rs:849:34
    |
849 |                   let tag_clause = format!(
    |  __________________________________^
850 | |             "e.id IN (SELECT t.event_id FROM tag t WHERE (name=? AND ({} OR {})))",
851 | |                     str_clause, blob_clause
852 | |                 );
    | |_________________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args

warning: variables can be used directly in the `format!` string
   --> src/repo/sqlite.rs:883:17
    |
883 |         let _ = write!(query, " ORDER BY e.created_at DESC LIMIT {}", lim);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
help: change this to
    |
883 -         let _ = write!(query, " ORDER BY e.created_at DESC LIMIT {}", lim);
883 +         let _ = write!(query, " ORDER BY e.created_at DESC LIMIT {lim}");
    |

warning: variables can be used directly in the `format!` string
   --> src/repo/sqlite.rs:910:18
    |
910 |         .map(|s| format!("SELECT distinct content, created_at FROM ({})", s))
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
help: change this to
    |
910 -         .map(|s| format!("SELECT distinct content, created_at FROM ({})", s))
910 +         .map(|s| format!("SELECT distinct content, created_at FROM ({s})"))
    |

warning: variables can be used directly in the `format!` string
   --> src/repo/sqlite_migration.rs:218:13
    |
218 | /             panic!(
219 | |                 "Database version is newer than supported by this executable (v{} > v{})",
220 | |                 curr_version, DB_VERSION
221 | |             );
    | |_____________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args

warning: unneeded late initialization
  --> src/repo/postgres.rs:80:13
   |
80 |             let repl_count:i64;
   |             ^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_late_init
help: declare `repl_count` here
   |
81 |             let repl_count:i64 = if is_lower_hex(&d_tag) && (d_tag.len() % 2 == 0) {
   |             ++++++++++++++++++++
help: remove the assignments from the branches
   |
82 ~                 sqlx::query_scalar(
83 |                     "SELECT count(*) AS count FROM event e LEFT JOIN tag t ON e.id=t.event_id WHERE e.pub_key=$1 AND e.kind=$2 AND t.name='d' AND t.value_hex=$3 AND e.created_at >= $4 LIMIT 1;")
 ...
88 |                     .fetch_one(&mut tx)
89 ~                     .await?
90 |             } else {
91 ~                 sqlx::query_scalar(
92 |                     "SELECT count(*) AS count FROM event e LEFT JOIN tag t ON e.id=t.event_id WHERE e.pub_key=$1 AND e.kind=$2 AND t.name='d' AND t.value=$3 AND e.created_at >= $4 LIMIT 1;")
 ...
97 |                     .fetch_one(&mut tx)
98 ~                     .await?
   |
help: add a semicolon after the `if` expression
   |
99 |             };
   |              +

warning: unneeded late initialization
   --> src/repo/postgres.rs:181:13
    |
181 |             let update_count;
    |             ^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_late_init
help: declare `update_count` here
    |
182 |             let update_count = if is_lower_hex(&d_tag) && (d_tag.len() % 2 == 0) {
    |             ++++++++++++++++++
help: remove the assignments from the branches
    |
183 ~                 sqlx::query("DELETE FROM event WHERE kind=$1 AND pub_key=$2 AND id IN (SELECT e.id FROM event e LEFT JOIN tag t ON e.id=t.event_id WHERE e.kind=$1 AND e.pub_key=$2 AND t.name='d' AND t.value_hex=$3 ORDER BY created_at DESC OFFSET 1);")
184 |                     .bind(e.kind as i64)
  ...
187 |                     .execute(&mut tx)
188 ~                     .await?.rows_affected()
189 |             } else {
190 ~                 sqlx::query("DELETE FROM event WHERE kind=$1 AND pub_key=$2 AND id IN (SELECT e.id FROM event e LEFT JOIN tag t ON e.id=t.event_id WHERE e.kind=$1 AND e.pub_key=$2 AND t.name='d' AND t.value=$3 ORDER BY created_at DESC OFFSET 1);")
191 |                     .bind(e.kind as i64)
  ...
194 |                     .execute(&mut tx)
195 ~                     .await?.rows_affected()
    |
help: add a semicolon after the `if` expression
    |
196 |             };
    |              +

warning: unneeded `return` statement
  --> src/repo/postgres_migration.rs:80:5
   |
80 |     return MigrationResult::Upgraded;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_return
   = note: `#[warn(clippy::needless_return)]` on by default
   = help: remove `return`

warning: the borrowed expression implements the required traits
   --> src/repo/postgres_migration.rs:205:61
    |
205 |                         sqlx::query(q).bind(&event_id).bind(&tagname).bind(hex::decode(tagval).ok()).execute(&mut update_tx).await?;
    |                                                             ^^^^^^^^ help: change this to: `tagname`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: the borrowed expression implements the required traits
   --> src/repo/postgres_migration.rs:208:61
    |
208 |                         sqlx::query(q).bind(&event_id).bind(&tagname).bind(tagval.as_bytes()).execute(&mut update_tx).await?;
    |                                                             ^^^^^^^^ help: change this to: `tagname`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: variables can be used directly in the `format!` string
  --> src/subscription.rs:73:38
   |
73 |                 map.serialize_entry(&format!("#{}",k), &vals)?;
   |                                      ^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
help: change this to
   |
73 -                 map.serialize_entry(&format!("#{}",k), &vals)?;
73 +                 map.serialize_entry(&format!("#{k}"), &vals)?;
   |

warning: this function has too many arguments (9/7)
  --> src/server.rs:53:1
   |
53 | / async fn handle_web_request(
54 | |     mut request: Request<Body>,
55 | |     repo: Arc<dyn NostrRepo>,
56 | |     settings: Settings,
...  |
62 | |     metrics: NostrMetrics,
63 | | ) -> Result<Response<Body>, Infallible> {
   | |_______________________________________^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#too_many_arguments
   = note: `#[warn(clippy::too_many_arguments)]` on by default

warning: variables can be used directly in the `format!` string
   --> src/server.rs:128:39
    |
128 |   ...                   Err(e) => println!(
    |  _________________________________^
129 | | ...                       "error when trying to upgrade connection \
130 | | ...                        from address {} to websocket connection. \
131 | | ...                        Error is: {}",
132 | | ...                       remote_addr, e
133 | | ...                   ),
    | |_______________________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args

warning: variables can be used directly in the `format!` string
   --> src/server.rs:142:50
    |
142 |                         Response::new(Body::from(format!("Failed to create websocket: {}", error)));
    |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
help: change this to
    |
142 -                         Response::new(Body::from(format!("Failed to create websocket: {}", error)));
142 +                         Response::new(Body::from(format!("Failed to create websocket: {error}")));
    |

warning: variables can be used directly in the `format!` string
   --> src/server.rs:349:13
    |
349 |             format!("tokio-ws-{}", id)
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
help: change this to
    |
349 -             format!("tokio-ws-{}", id)
349 +             format!("tokio-ws-{id}")
    |

warning: variables can be used directly in the `format!` string
   --> src/server.rs:481:13
    |
481 |             eprintln!("server error: {}", e);
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
help: change this to
    |
481 -             eprintln!("server error: {}", e);
481 +             eprintln!("server error: {e}");
    |

warning: this function has too many arguments (8/7)
   --> src/server.rs:544:1
    |
544 | / async fn nostr_server(
545 | |     repo: Arc<dyn NostrRepo>,
546 | |     client_info: ClientInfo,
547 | |     settings: Settings,
...   |
552 | |     metrics: NostrMetrics,
553 | | ) {
    | |__^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#too_many_arguments

warning: variables can be used directly in the `format!` string
   --> src/server.rs:642:36
    |
642 |                     let send_str = format!("[\"EOSE\",\"{}\"]", subesc);
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
help: change this to
    |
642 -                     let send_str = format!("[\"EOSE\",\"{}\"]", subesc);
642 +                     let send_str = format!("[\"EOSE\",\"{subesc}\"]");
    |

warning: variables can be used directly in the `format!` string
   --> src/server.rs:669:54
    |
669 |                         ws_stream.send(Message::Text(format!("[\"EVENT\",\"{}\",{}]", subesc, event_str))).await.ok();
    |                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
help: change this to
    |
669 -                         ws_stream.send(Message::Text(format!("[\"EVENT\",\"{}\",{}]", subesc, event_str))).await.ok();
669 +                         ws_stream.send(Message::Text(format!("[\"EVENT\",\"{subesc}\",{event_str}]"))).await.ok();
    |

warning: variables can be used directly in the `format!` string
   --> src/server.rs:695:66
    |
695 | ...                   make_notice_message(&Notice::message(format!("message too large ({} > {})",size, max_size)))).await.ok();
    |                                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
help: change this to
    |
695 -                             make_notice_message(&Notice::message(format!("message too large ({} > {})",size, max_size)))).await.ok();
695 +                             make_notice_message(&Notice::message(format!("message too large ({size} > {max_size})")))).await.ok();
    |

warning: variables can be used directly in the `format!` string
   --> src/server.rs:744:51
    |
744 | ...                   let msg = format!("The event created_at field is out of the acceptable range (+{}sec) for this relay.",fut_sec);
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
help: change this to
    |
744 -                                         let msg = format!("The event created_at field is out of the acceptable range (+{}sec) for this relay.",fut_sec);
744 +                                         let msg = format!("The event created_at field is out of the acceptable range (+{fut_sec}sec) for this relay.");
    |

warning: variables can be used directly in the `format!` string
   --> src/server.rs:752:92
    |
752 | ...                   ws_stream.send(make_notice_message(&Notice::invalid(evid, &format!("{}", e)))).await.ok();
    |                                                                                  ^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
help: change this to
    |
752 -                                 ws_stream.send(make_notice_message(&Notice::invalid(evid, &format!("{}", e)))).await.ok();
752 +                                 ws_stream.send(make_notice_message(&Notice::invalid(evid, &format!("{e}")))).await.ok();
    |

warning: variables can be used directly in the `format!` string
   --> src/server.rs:785:89
    |
785 | ...                   ws_stream.send(make_notice_message(&Notice::message(format!("Subscription error: {}", e)))).await.ok();
    |                                                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
help: change this to
    |
785 -                                     ws_stream.send(make_notice_message(&Notice::message(format!("Subscription error: {}", e)))).await.ok();
785 +                                     ws_stream.send(make_notice_message(&Notice::message(format!("Subscription error: {e}")))).await.ok();
    |

warning: `nostr-rs-relay` (lib) generated 36 warnings
warning: variables can be used directly in the `format!` string
  --> src/bin/bulkloader.rs:38:6
   |
38 |         panic!("cannot write to schema other than v{}", DB_VERSION);
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
   = note: `#[warn(clippy::uninlined_format_args)]` on by default
help: change this to
   |
38 -         panic!("cannot write to schema other than v{}", DB_VERSION);
38 +         panic!("cannot write to schema other than v{DB_VERSION}");
   |

warning: `nostr-rs-relay` (bin "bulkloader") generated 1 warning
    Finished dev [unoptimized + debuginfo] target(s) in 0.33s
</pre>
</details>