### PR TITLE
Add systemd service file and guide

### DIFF
--- a/contrib/nostr-rs-relay.service
+++ b/contrib/nostr-rs-relay.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=nostr-rs-relay
+[Service]
+User=REPLACE_WITH_YOUR_USERNAME
+WorkingDirectory=/usr/bin/
+Environment=RUST_LOG=warn,nostr_rs_relay=info
+ExecStart=nostr-rs-relay --config /etc/nostr-rs-relay/config.toml
+TimeoutStopSec=10
+Restart=on-failure
+RestartSec=5
+[Install]
+WantedBy=multi-user.target

--- a/docs/run-as-linux-system-process.md
+++ b/docs/run-as-linux-system-process.md
@@ -1,0 +1,39 @@
+# Run as a linux system process
+
+Docker makes it easy to spin up and down environments but it's also possible to run `nostr-rs-relay` as a systemd linux process.
+This guide assumes you're on a Linux machine and that Rust is already installed.
+
+## Instructions
+
+### Build nostr-rs-relay from source
+Start by building the application from source. Here is how to do that:
+1. `git clone https://github.com/scsibug/nostr-rs-relay.git`
+2. `cd nostr-rs-relay`
+3. `cargo build --release`
+
+### Place the files where they belong
+We want to palce the nostr-rs-relay binary and the config.toml file where they belong. While still in the root level of the nostr-rs-relay folder you cloned in last step, run the following commands:
+1. `sudo cp target/release/nostr-rs-relay /usr/local/bin/`
+2. `sudo mkdir /etc/nostr-rs-relay`
+2. `sudo cp config.toml /etc/nostr-rs-relay`
+
+### Create the Systemd service file
+We need to create a new Systemd service file. These files are placed in the `/etc/systemd/system/` folder where you will find many other services running. 
+
+1. `sudo vim /etc/systemd/system/nostr-rs-relay.service`
+2. Paste in the contents of [this service file](../contrib/nostr-rs-relay.service). Remember to replace the `User` value with your own username.
+3. Save the file and exit your text editor
+
+
+### Run the service
+To get the service running, we need to reload the systemd daemon and enable the service.
+
+1. `sudo systemctl daemon-reload`
+2. `sudo systemctl start nostr-rs-relay.service`
+3. `sudo systemctl status nostr-rs-relay.service`
+
+
+### Tips
+
+#### Logs
+The application will write logs to the journal. To read it, execute `sudo journalctl -f -u nostr-rs-relay`


### PR DESCRIPTION
Hello!

This PR adds an example Systemd service file and a guide doc to instruct how to run nostr-rs-relay as a systemd service instead of in a docker container.

There are probably stuff that can be improved on the service file and the guide so hopefully people can contribute either in this PR or later on!