### PR TITLE
NIP-42: use 'restricted:' prefix for auth error messages

### DIFF
--- a/src/notice.rs
+++ b/src/notice.rs
@@ -5,6 +5,7 @@ pub enum EventResultStatus {
     Blocked,
     RateLimited,
     Error,
+    Restricted,
 }
 
 pub struct EventResult {
@@ -24,7 +25,7 @@ impl EventResultStatus {
     pub fn to_bool(&self) -> bool {
         match self {
             Self::Duplicate | Self::Saved => true,
-            Self::Invalid | Self::Blocked | Self::RateLimited | Self::Error => false,
+            Self::Invalid | Self::Blocked | Self::RateLimited | Self::Error | Self::Restricted => false,
         }
     }
 
@@ -37,6 +38,7 @@ impl EventResultStatus {
             Self::Blocked => "blocked",
             Self::RateLimited => "rate-limited",
             Self::Error => "error",
+            Self::Restricted => "restricted",
         }
     }
 }
@@ -79,6 +81,11 @@ impl Notice {
     #[must_use]
     pub fn error(id: String, msg: &str) -> Notice {
         Notice::prefixed(id, msg, EventResultStatus::Error)
+    }
+
+    #[must_use]
+    pub fn restricted(id: String, msg: &str) -> Notice {
+        Notice::prefixed(id, msg, EventResultStatus::Restricted)
     }
 
     #[must_use]

--- a/src/server.rs
+++ b/src/server.rs
@@ -1317,7 +1317,7 @@ async fn nostr_server(
                                                 },
                                                 Err(e) => {
                                                     info!("authentication error: {} (cid: {})", e, cid);
-                                                    ws_stream.send(make_notice_message(&Notice::message(format!("Authentication error: {e}")))).await.ok();
+                                                    ws_stream.send(make_notice_message(&Notice::restricted(event.id, format!("authentication error: {e}").as_str()))).await.ok();
                                                 },
                                             }
                                         }


### PR DESCRIPTION
Just keeping up with the NIP.