### PR TITLE
Problem: payment status isn't updated until an event is published

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -499,7 +499,7 @@ async fn handle_web_request(
     </div>
     <div>
         <p> This page will not refresh </p>
-        <p> Verify admission <a href=/account?pubkey={}>here</a> once you have paid</p>
+        <p> After you have paid the invoice, publish an event to trigger the relay to check for payment. Events published after that should be accepted by the relay and your admission status should be shown <a href=/account?pubkey={}>here</a>.</p>
     </div>
     </div>
   </body>


### PR DESCRIPTION
Problem: payment status isn't updated until an event is published, this is a bit confusing for the user. 

Simplest solution: change the wording to tell the user to send an event and trigger the relay to check for payment.