### PR TITLE
feat: config sending dms on pay to relay signup

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -202,6 +202,9 @@ reject_future_seconds = 1800
 # LNBits api secret
 #api_secret = "<ln bits api>"
 
+# Nostr direct message on signup
+#direct_message=true 
+
 # Terms of service
 #terms_message = """
 #This service (and supporting services) are provided "as is", without warranty of any kind, express or implied.
@@ -223,4 +226,6 @@ reject_future_seconds = 1800
 
 # Whether or not new sign ups should be allowed
 #sign_ups = false
+
+# optional if `direct_message=false`
 #secret_key = "<nostr nsec>"

--- a/src/config.rs
+++ b/src/config.rs
@@ -93,8 +93,9 @@ pub struct PayToRelay {
     pub node_url: String,
     pub api_secret: String,
     pub terms_message: String,
-    pub sign_ups: bool, // allow new users to sign up to relay
-    pub secret_key: String,
+    pub sign_ups: bool,       // allow new users to sign up to relay
+    pub direct_message: bool, // Send direct message to user with invoice and terms
+    pub secret_key: Option<String>,
     pub processor: Processor,
 }
 
@@ -243,7 +244,14 @@ impl Settings {
             // Should check that url is valid
             assert_ne!(settings.pay_to_relay.node_url, "");
             assert_ne!(settings.pay_to_relay.terms_message, "");
-            assert_ne!(settings.pay_to_relay.secret_key, "");
+
+            if settings.pay_to_relay.direct_message {
+                assert_ne!(
+                    settings.pay_to_relay.secret_key,
+                    Some("<nostr nsec>".to_string())
+                );
+                assert!(settings.pay_to_relay.secret_key.is_some());
+            }
         }
 
         Ok(settings)
@@ -306,7 +314,8 @@ impl Default for Settings {
                 node_url: "".to_string(),
                 api_secret: "".to_string(),
                 sign_ups: false,
-                secret_key: "".to_string(),
+                direct_message: true,
+                secret_key: None,
                 processor: Processor::LNBits,
             },
             verified_users: VerifiedUsers {

--- a/src/payment/mod.rs
+++ b/src/payment/mod.rs
@@ -25,7 +25,7 @@ pub struct Payment {
     /// Settings
     settings: crate::config::Settings,
     // Nostr Keys
-    nostr_keys: Keys,
+    nostr_keys: Option<Keys>,
     /// Payment Processor
     processor: Arc<dyn PaymentProcessor>,
 }
@@ -102,7 +102,11 @@ impl Payment {
         info!("Create payment handler");
 
         // Create nostr key from sk string
-        let nostr_keys = Keys::from_sk_str(&settings.pay_to_relay.secret_key)?;
+        let nostr_keys = if let Some(secret_key) = &settings.pay_to_relay.secret_key {
+            Some(Keys::from_sk_str(secret_key)?)
+        } else {
+            None
+        };
 
         // Create processor kind defined in settings
         let processor = match &settings.pay_to_relay.processor {
@@ -189,6 +193,11 @@ impl Payment {
         pubkey: &str,
         invoice_info: &InvoiceInfo,
     ) -> Result<()> {
+        let nostr_keys = match &self.nostr_keys {
+            Some(key) => key,
+            None => return Err(Error::CustomError("Nostr key not defined".to_string())),
+        };
+
         // Create Nostr key from pk
         let key = Keys::from_pk_str(pubkey)?;
 
@@ -196,16 +205,16 @@ impl Payment {
 
         // Event DM with terms of service
         let message_event: NostrEvent = EventBuilder::new_encrypted_direct_msg(
-            &self.nostr_keys,
+            nostr_keys,
             pubkey,
             &self.settings.pay_to_relay.terms_message,
         )?
-        .to_event(&self.nostr_keys)?;
+        .to_event(nostr_keys)?;
 
         // Event DM with invoice
         let invoice_event: NostrEvent =
-            EventBuilder::new_encrypted_direct_msg(&self.nostr_keys, pubkey, &invoice_info.bolt11)?
-                .to_event(&self.nostr_keys)?;
+            EventBuilder::new_encrypted_direct_msg(nostr_keys, pubkey, &invoice_info.bolt11)?
+                .to_event(nostr_keys)?;
 
         // Persist DM events to DB
         self.repo.write_event(&message_event.clone().into()).await?;
@@ -242,8 +251,10 @@ impl Payment {
             .create_invoice_record(&key, invoice_info.clone())
             .await?;
 
-        // Admission event invoice and terms to pubkey that is joining
-        self.send_admission_message(pubkey, &invoice_info).await?;
+        if self.settings.pay_to_relay.direct_message {
+            // Admission event invoice and terms to pubkey that is joining
+            self.send_admission_message(pubkey, &invoice_info).await?;
+        }
 
         Ok(invoice_info)
     }


### PR DESCRIPTION
Add config var to disable sending nostr direct messages if `direct_message=false`

closes #137 