### PR TITLE
Addition of icon option according to NIP-11

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -20,6 +20,9 @@ description = "A newly created nostr-rs-relay.\n\nCustomize this with your own i
 # ICO format.
 #favicon = "favicon.ico"
 
+# URL of Relay's icon.
+#relay_icon = "https://example.test/img.png"
+
 [diagnostics]
 # Enable tokio tracing (for use with tokio-console)
 #tracing = false

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,7 @@ pub struct Info {
     pub pubkey: Option<String>,
     pub contact: Option<String>,
     pub favicon: Option<String>,
+    pub relay_icon: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -268,6 +269,7 @@ impl Default for Settings {
                 pubkey: None,
                 contact: None,
                 favicon: None,
+                relay_icon: None,
             },
             diagnostics: Diagnostics { tracing: false },
             database: Database {

--- a/src/info.rs
+++ b/src/info.rs
@@ -45,6 +45,8 @@ pub struct RelayInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub contact: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon: Option<String>,        
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub supported_nips: Option<Vec<i64>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub software: Option<String>,
@@ -124,6 +126,7 @@ impl From<Settings> for RelayInfo {
             limitation: Some(limitations),
             payment_url,
             fees,
+            icon: i.relay_icon,
         }
     }
 }


### PR DESCRIPTION
[NIP-11 offers an `icon` attribute](https://github.com/nostr-protocol/nips/blob/master/11.md#icon) to provide a relay icon URL to the clients.

This is a simple addition of this feature to nostr-rs-relay.

Thank you for considering it. 