### PR TITLE
Fail if wrong config path

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,8 @@ use nostr_rs_relay::server::start_server;
 use std::sync::mpsc as syncmpsc;
 use std::sync::mpsc::{Receiver as MpscReceiver, Sender as MpscSender};
 use std::thread;
+use std::path::Path;
+use std::process;
 #[cfg(not(target_env = "msvc"))]
 use tikv_jemallocator::Jemalloc;
 use tracing::info;
@@ -23,6 +25,11 @@ fn main() {
 
     // get config file name from args
     let config_file_arg = args.config;
+    // Quits if config file path does not exist
+    if !Path::new(&config_file_arg).exists() {
+        eprintln!("Config file not found: {}", &config_file_arg);
+        process::exit(1);
+    }
 
     let mut _log_guard: Option<WorkerGuard> = None;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use std::sync::mpsc as syncmpsc;
 use std::sync::mpsc::{Receiver as MpscReceiver, Sender as MpscSender};
 use std::thread;
 use std::path::Path;
-use std::fs
+use std::fs;
 use std::process;
 #[cfg(not(target_env = "msvc"))]
 use tikv_jemallocator::Jemalloc;

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,11 +46,11 @@ fn main() {
         process::exit(1);
     }
 
-    if !path.is_readable() {
-        eprintln!("Config file is not readable: {}", &config_file_path);
+    if let Err(err) = fs::File::open(&path) {
+        eprintln!("Config file is not readable: {}", err);
         process::exit(1);
     }
- 
+
 
     let mut _log_guard: Option<WorkerGuard> = None;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,8 +25,9 @@ fn main() {
 
     // get config file name from args
     let config_file_arg = args.config;
+
     // Quits if config file path does not exist
-    let config_file_path: &OsStr = OsStr::new(config_file_arg);
+    let config_file_path = config_file_arg.as_ref().map(|x| &**x).unwrap()
     if !Path::new(&config_file_path).exists() {
         eprintln!("Config file not found: {}", &config_file_path);
         process::exit(1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ fn main() {
     let config_file_arg = args.config;
 
     // Quits if config file path does not exist
-    let config_file_path = config_file_arg.as_ref().map(|x| &**x).unwrap()
+    let config_file_path = config_file_arg.as_ref().map(|x| &**x).unwrap();
     if !Path::new(&config_file_path).exists() {
         eprintln!("Config file not found: {}", &config_file_path);
         process::exit(1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,8 +26,9 @@ fn main() {
     // get config file name from args
     let config_file_arg = args.config;
     // Quits if config file path does not exist
-    if !Path::new(&config_file_arg).exists() {
-        eprintln!("Config file not found: {}", &config_file_arg);
+    let config_file_path: &OsStr = OsStr::new(config_file_arg);
+    if !Path::new(&config_file_path).exists() {
+        eprintln!("Config file not found: {}", &config_file_path);
         process::exit(1);
     }
 


### PR DESCRIPTION
As referenced in https://github.com/scsibug/nostr-rs-relay/issues/145

This will make the program fail if the config path is invalid instead of loading the default configuration. Apologies if it looks ugly. Not a fluent developer.

```
$ ./target/release/nostr-rs-relay --config /this/path/does/not/exist.toml
Config file not found: /this/path/does/not/exist.toml
```

```
$ ./target/release/nostr-rs-relay --config /etc/actual-nostr-rs-config.toml 
$ ss -nltp | grep nostr-rs-relay
LISTEN 0      128          0.0.0.0:18080      0.0.0.0:*    users:(("nostr-rs-relay",pid=64071,fd=24))
```

```
$ sudo chown root:root /etc/actual-nostr-rs-config.toml 
$ sudo chmod 600 /etc/actual-nostr-rs-config.toml 
$ ./target/release/nostr-rs-relay --config /etc/actual-nostr-rs-config.toml 
Config file is not readable: Permission denied (os error 13)
```