### PR TITLE
[#141] - Fix Build - Set build_server to true

### DIFF
--- a/examples/nauthz/build.rs
+++ b/examples/nauthz/build.rs
@@ -1,6 +1,6 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::configure()
-        .build_server(false)
+        .build_server(true)
         .protoc_arg("--experimental_allow_proto3_optional")
         .compile(&["../../proto/nauthz.proto"], &["../../proto"])?;
     Ok(())


### PR DESCRIPTION
This will allow us to compile the gRPC example.

Fix for #141