### PR TITLE
fix: send `OK` message for ephemeral events

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -401,6 +401,9 @@ pub async fn db_writer(
                 start.elapsed()
             );
             event_write = true;
+
+            // send OK message
+            notice_tx.try_send(Notice::saved(event.id)).ok();
         } else {
             match repo.write_event(&event).await {
                 Ok(updated) => {


### PR DESCRIPTION
Hi, according to last changes in `NIP01`, the `OK` message MUST be sent in response to every `EVENT` message:  https://github.com/nostr-protocol/nips/blob/4b9f13d983245e4dd166f102308afc28b8bb1603/01.md?plain=1#L153