### PR TITLE
improve: remove dm to publisher of event

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -206,7 +206,7 @@ reject_future_seconds = 1800
 #api_secret = "<ln bits api>"
 
 # Nostr direct message on signup
-#direct_message=true
+#direct_message=false
 
 # Terms of service
 #terms_message = """

--- a/src/config.rs
+++ b/src/config.rs
@@ -320,7 +320,7 @@ impl Default for Settings {
                 node_url: "".to_string(),
                 api_secret: "".to_string(),
                 sign_ups: false,
-                direct_message: true,
+                direct_message: false,
                 secret_key: None,
                 processor: Processor::LNBits,
             },

--- a/src/db.rs
+++ b/src/db.rs
@@ -261,7 +261,7 @@ pub async fn db_writer(
                     ) => {
                         // User does not exist
                         info!("Unregistered user");
-                        if settings.pay_to_relay.sign_ups {
+                        if settings.pay_to_relay.sign_ups && settings.pay_to_relay.direct_message {
                             payment_tx
                                 .send(PaymentMessage::NewAccount(event.pubkey))
                                 .ok();


### PR DESCRIPTION

While sending dms to users who are not signed up but have attempted to publish events, it is now disabled by default. This stops the creation of extra invoices for pubkeys that may have no intention of signing up for the relay. It also reduced the number of dms that are created.

Fixes: #170 