### PR TITLE
Fix id based sqlite query

### DIFF
--- a/src/repo/sqlite.rs
+++ b/src/repo/sqlite.rs
@@ -1016,7 +1016,8 @@ fn query_from_filter(f: &ReqFilter) -> (String, Vec<Box<dyn ToSql>>, Option<Stri
         let mut id_searches: Vec<String> = vec![];
         for id in idvec {
             id_searches.push("event_hash=?".to_owned());
-            params.push(Box::new(id.clone()));
+            let id_bin = hex::decode(id).ok();
+            params.push(Box::new(id_bin));
         }
         if idvec.is_empty() {
             // if the ids list was empty, we should never return


### PR DESCRIPTION
Currently, ID-based queries in SQLite are failing. For example, the command:

```sh
nak req -i $(nak req -k 1 -l 1 wss://nostr.8777.ch | jq -r '.id') wss://nostr.8777.ch
```
returns nothing.

This small PR addresses the issue by encoding the ID as a hex value in the same manner as it's done for authors.

Thank you for maintaining this project, and feel free to adjust this as needed!