### PR TITLE
nip42 authorized whitelisted client can always post

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -173,6 +173,8 @@ limit_scrapers = false
 #]
 # Enable NIP-42 authentication
 #nip42_auth = false
+# Allow whitelisted NIP-42 authenticated client to post from any pubkey
+#nip42_whitelist = false
 # Send DMs (kind 4 and 44) and gift wraps (kind 1059) only to their authenticated recipients
 #nip42_dms = false
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -83,6 +83,7 @@ pub struct Limits {
 pub struct Authorization {
     pub pubkey_whitelist: Option<Vec<String>>, // If present, only allow these pubkeys to publish events
     pub nip42_auth: bool,                      // if true enables NIP-42 authentication
+    pub nip42_whitelist: bool,                 // if true allows whitelisted NIP-42 authenticated clients to publish events from any pubkey
     pub nip42_dms: bool, // if true send DMs only to their authenticated recipients
 }
 
@@ -325,6 +326,7 @@ impl Default for Settings {
             authorization: Authorization {
                 pubkey_whitelist: None, // Allow any address to publish
                 nip42_auth: false,      // Disable NIP-42 authentication
+                nip42_whitelist: false, // Disable NIP-42 whitelist
                 nip42_dms: false,       // Send DMs to everybody
             },
             pay_to_relay: PayToRelay {


### PR DESCRIPTION
Fixes #214.

Adds a new setting `nip42_whitelist` (default `false`) which lets any NIP42 authenticated client whose pubkey is on the whitelist post anything.