### PR TITLE
Add CARGO_LOG build arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM docker.io/library/rust:1-bookworm as builder
+ARG CARGO_LOG
 RUN apt-get update \
     && apt-get install -y cmake protobuf-compiler \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Add the `CARGO_LOG` build argument into the build environment so that _if_ it is specified we can then see some stuff