### PR TITLE
Fix sqlite schema comment

### DIFF
--- a/src/repo/sqlite_migration.rs
+++ b/src/repo/sqlite_migration.rs
@@ -40,7 +40,7 @@ PRAGMA user_version = {};
 -- Event Table
 CREATE TABLE IF NOT EXISTS event (
 id INTEGER PRIMARY KEY,
-event_hash BLOB NOT NULL, -- 4-byte hash
+event_hash BLOB NOT NULL, -- 32-byte SHA256 hash
 first_seen INTEGER NOT NULL, -- when the event was first seen (not authored!) (seconds since 1970)
 created_at INTEGER NOT NULL, -- when the event was authored
 expires_at INTEGER, -- when the event expires and may be deleted


### PR DESCRIPTION
`event_hash` is the raw SHA256 hash of the event, not 4-byte hash.