### PR TITLE
feat: add domain whitelist

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ chrono = "0.4.23"
 prometheus = "0.13.3"
 indicatif = "0.17.3"
 bech32 = "0.9.1"
-url = "2.3.1"
+url = "2.5.0"
 qrcode = { version = "0.12.0", default-features = false, features = ["svg"] }
 nostr = { version = "0.18.0", default-features = false, features = ["base", "nip04", "nip19"] }
 log = "0.4"

--- a/config.toml
+++ b/config.toml
@@ -176,6 +176,9 @@ limit_scrapers = false
 # Send DMs (kind 4 and 44) and gift wraps (kind 1059) only to their authenticated recipients
 #nip42_dms = false
 
+# Domain names that are allowed to publish events
+#domain_only_whitelist = ["damus.io"]
+
 [verified_users]
 # NIP-05 verification of users.  Can be "enabled" to require NIP-05
 # metadata for event authors, "passive" to perform validation but

--- a/src/config.rs
+++ b/src/config.rs
@@ -84,6 +84,7 @@ pub struct Authorization {
     pub pubkey_whitelist: Option<Vec<String>>, // If present, only allow these pubkeys to publish events
     pub nip42_auth: bool,                      // if true enables NIP-42 authentication
     pub nip42_dms: bool, // if true send DMs only to their authenticated recipients
+    pub domain_only_whitelist: Option<Vec<String>>, // If present, only allow verified domains to publish events
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -323,9 +324,10 @@ impl Default for Settings {
                 limit_scrapers: false,
             },
             authorization: Authorization {
-                pubkey_whitelist: None, // Allow any address to publish
-                nip42_auth: false,      // Disable NIP-42 authentication
-                nip42_dms: false,       // Send DMs to everybody
+                pubkey_whitelist: None,      // Allow any address to publish
+                nip42_auth: false,           // Disable NIP-42 authentication
+                nip42_dms: false,            // Send DMs to everybody
+                domain_only_whitelist: None, // Allow any domain
             },
             pay_to_relay: PayToRelay {
                 enabled: false,


### PR DESCRIPTION
Good morning! I don't know if this isn't against nostr rules, but I need to temporarily disable access to my relay by other clients. My client is still in progress and spam is currently not helping me to build something useful for the public! So I am adding such restriction to fork, but if you think this feature might be valuable for others then please have a look. Thanks again for building this relay! 