### PR TITLE
Support compiling and running on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  pull_request:
 
 jobs:
   test_nostr-rs-relay:
@@ -28,6 +29,34 @@ jobs:
       #   run: |
       #     cargo fmt -- --check
       #     cargo clippy -- -D warnings
+
+      - name: Test
+        run: |
+          cargo check
+          cargo test --all
+
+      - name: Build
+        run: |
+          cargo build --release --locked
+
+  build_windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install protobuf compiler
+        run: choco install protoc -y
+
+      - name: Update local toolchain
+        run: |
+          rustup update
+          rustup component add clippy
+
+      - name: Toolchain info
+        run: |
+          cargo --version --verbose
+          rustc --version
+          cargo clippy --version
 
       - name: Test
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,11 +57,16 @@ url = "2.3.1"
 qrcode = { version = "0.12.0", default-features = false, features = ["svg"] }
 nostr = { version = "0.18.0", default-features = false, features = ["base", "nip04", "nip19"] }
 log = "0.4"
-cln-rpc = "0.1.9"
 itertools = "0.14.0"
 
 [target.'cfg(all(not(target_env = "msvc"), not(target_os = "openbsd")))'.dependencies]
 tikv-jemallocator = "0.5"
+
+# cln-rpc unconditionally uses Unix domain sockets and does not build on Windows.
+# The CLN-REST payment processor (which only needs cln-rpc's model types) is
+# therefore excluded from Windows builds.
+[target.'cfg(not(windows))'.dependencies]
+cln-rpc = "0.1.9"
 
 [dev-dependencies]
 anyhow = "1"

--- a/src/payment/mod.rs
+++ b/src/payment/mod.rs
@@ -1,5 +1,6 @@
 use crate::error::{Error, Result};
 use crate::event::Event;
+#[cfg(not(windows))]
 use crate::payment::cln_rest::ClnRestPaymentProcessor;
 use crate::payment::lnbits::LNBitsPaymentProcessor;
 use crate::repo::NostrRepo;
@@ -11,6 +12,7 @@ use async_trait::async_trait;
 use nostr::key::{FromPkStr, FromSkStr};
 use nostr::{key::Keys, Event as NostrEvent, EventBuilder};
 
+#[cfg(not(windows))]
 pub mod cln_rest;
 pub mod lnbits;
 
@@ -114,7 +116,14 @@ impl Payment {
         // Create processor kind defined in settings
         let processor: Arc<dyn PaymentProcessor> = match &settings.pay_to_relay.processor {
             Processor::LNBits => Arc::new(LNBitsPaymentProcessor::new(&settings)),
+            #[cfg(not(windows))]
             Processor::ClnRest => Arc::new(ClnRestPaymentProcessor::new(&settings)?),
+            #[cfg(windows)]
+            Processor::ClnRest => {
+                return Err(Error::CustomError(
+                    "ClnRest payment processor is not supported on Windows builds".to_string(),
+                ))
+            }
         };
 
         Ok(Payment {

--- a/src/server.rs
+++ b/src/server.rs
@@ -671,8 +671,23 @@ fn get_header_string(header: &str, headers: &HeaderMap) -> Option<String> {
 
 // return on a control-c or internally requested shutdown signal
 async fn ctrl_c_or_signal(mut shutdown_signal: Receiver<()>) {
-    let mut term_signal = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
-        .expect("could not define signal");
+    // Listen for SIGTERM on unix platforms. On other platforms (e.g. Windows)
+    // this future never resolves, leaving ctrl-c and the requested-shutdown
+    // channel as the shutdown triggers.
+    let term_signal = async {
+        #[cfg(unix)]
+        {
+            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+                .expect("could not define signal")
+                .recv()
+                .await;
+        }
+        #[cfg(not(unix))]
+        {
+            futures::future::pending::<()>().await;
+        }
+    };
+    tokio::pin!(term_signal);
     #[allow(clippy::never_loop)]
     loop {
         tokio::select! {
@@ -685,7 +700,7 @@ async fn ctrl_c_or_signal(mut shutdown_signal: Receiver<()>) {
                 info!("Shutting down webserver due to SIGINT");
                 break;
             },
-            _ = term_signal.recv() => {
+            _ = &mut term_signal => {
                 info!("Shutting down webserver due to SIGTERM");
                 break;
             },


### PR DESCRIPTION
Closes #25 (Windows support).

Three Unix-only assumptions prevented Windows builds. All fixes are platform-gated, so **the Linux build is completely unchanged** — two of the three source files reduce to the exact original tokens on a non-Windows target, and the third is behavior-equivalent (details below).

## Changes

**1. `cln-rpc` → non-Windows target dependency.** `cln-rpc` unconditionally uses tokio Unix domain sockets and cannot compile on Windows. The relay only uses its *model types* (in the CLN-REST payment processor), but Cargo compiles a crate as a unit, so the import sinks the whole build. Moved it to `[target.'cfg(not(windows))'.dependencies]` (same mechanism already used for `tikv-jemallocator`) and gated the `cln_rest` module. Selecting the `ClnRest` processor on Windows now returns a clear runtime error. **LNbits and all core relay functionality are unaffected.**

**2. SIGTERM handling.** `tokio::signal::unix` doesn't exist on Windows. The SIGTERM branch of `ctrl_c_or_signal` is now gated: on unix it behaves exactly as before; on other platforms it's a never-resolving future, leaving Ctrl-C and the internal shutdown channel as the triggers (`ctrl_c()` already covers console close/Ctrl-C on Windows). The shutdown loop already broke on the first signal, so behavior on unix is identical.

**3. CI.** Added a `windows-latest` job alongside the existing Ubuntu job (installs `protoc` via choco, runs the same check/test/build), and added a `pull_request` trigger. The existing Linux job is untouched.

## Verification

Both jobs pass on GitHub Actions (Linux + Windows): `cargo check`, `cargo test --all`, and `cargo build --release --locked`. Verified on my fork before opening this PR.

## Note for builders

As on every platform, building requires `protoc` on the host (`tonic-build`). On Windows: `choco install protoc` or `winget install Google.Protobuf`.